### PR TITLE
Add RAM Coffers - NUMA-aware weight banking for LLM inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ To add, remove or change things on the list:
 - [Umpire](https://github.com/LLNL/Umpire) - An application-focused API for memory management on NUMA & GPU architectures
 - [memkind](https://memkind.github.io/memkind/) - A heap manager which enables control of memory characteristics and a partitioning of the heap between kinds of memory
 
+- [RAM Coffers](https://github.com/Scottcjn/ram-coffers) - NUMA-aware weight banking for LLM inference on IBM POWER8, routing model weights to cognitive-function-mapped NUMA nodes with prefetch hints
+
 ## Observation and profiling tools
 - [numastat](https://github.com/numactl/numactl) - A program display NUMA allocation statistics
 - [NUMACC](https://github.com/mJace/numacc) - A golang-based tool to check CPU affinity and NUMA configuration for containers and pods


### PR DESCRIPTION
Adding [RAM Coffers](https://github.com/Scottcjn/ram-coffers) to the NUMA-aware memory placement section.

RAM Coffers is a NUMA-aware weight banking system for LLM inference on IBM POWER8, mapping model weights to cognitive-function-mapped NUMA nodes (4 nodes, 512GB total). Features include:

- Multi-bank NUMA weight routing with cosine similarity
- dcbt resident prefetch hints for L2/L3 cache residency
- Neuromorphic cognitive mapping (brain hemisphere → NUMA topology)
- Non-bijunctive collapse via vec_perm for attention pruning

Benchmarked on POWER8 S824 with 4 NUMA nodes (114-189GB per node, 215-425 MB/s per bank).